### PR TITLE
Increased the visibility of comments

### DIFF
--- a/themes/synthwave-x-fluoromachine.json
+++ b/themes/synthwave-x-fluoromachine.json
@@ -168,10 +168,14 @@
     {
       "name": "Comment",
       "scope": [
-        "comment"
+        "comment",
+        "string.quoted.docstring.multi.python",
+        "string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
+        "string.quoted.docstring.multi.python punctuation.definition.string.end.python"
       ],
       "settings": {
-        "foreground": "#FD971F"
+        "foreground": "#FD971F",
+        "fontStyle": "italic"
       }
     },
     {


### PR DESCRIPTION
When I applied the theme, the first thing I noticed is that, for some reason or other, comments didn't appear very distinct and were somewhat difficult to see. For some reason, despite the syntax looking very similar, it basically just didn't take effect. I've seen this issue with the base synthwave x flouromachine theme as well, which seems to have been forked before synthwave 84 underwent some significant improvements to language support. This block is actually stolen pretty much verbatim from synthwave 84.

Before:
![image](https://github.com/user-attachments/assets/23da7a29-df2e-440c-856a-c0679098b197)

After: 
![image](https://github.com/user-attachments/assets/b5e98aaf-1669-4339-bd0b-9774f2dcc338)
